### PR TITLE
Extended plugin to check .cljs and .cljc files.

### DIFF
--- a/src/leiningen/annotations.clj
+++ b/src/leiningen/annotations.clj
@@ -7,7 +7,7 @@
 (defn project-files
   "Obtain a list of all Clojure files in the current project."
   [project-dir]
-  (filter #(.endsWith (.getName %) ".clj")
+  (filter #(re-matches #".+\.clj(|s|c)$" (.getName %))
           (file-seq (io/file project-dir))))
 
 (defn relative-path


### PR DESCRIPTION
Many Clojure projects now also include .cljs and .cljc files in addition to the regular .clj files.
The annotations plugin not catching annotations in these files can give you a false impression of the state of a project.